### PR TITLE
Client ip

### DIFF
--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -24,7 +24,8 @@ class ClientFactory
         $option = make(Option::class);
         $option->setServer($config->get('apollo.server', 'http://127.0.0.1:8080'))
             ->setAppid($config->get('apollo.appid', ''))
-            ->setCluster($config->get('apollo.cluster', ''));
+            ->setCluster($config->get('apollo.cluster', ''))
+            ->setClientIp(current(swoole_get_local_ip()));
         $namespaces = $config->get('apollo.namespaces', []);
         $callbacks = [];
         foreach ($namespaces as $namespace => $callable) {

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -24,7 +24,7 @@ class ClientFactory
         $option = make(Option::class);
         $option->setServer($config->get('apollo.server', 'http://127.0.0.1:8080'))
             ->setAppid($config->get('apollo.appid', ''))
-            ->setCluster($config->get('apollo.cluster', ''))  
+            ->setCluster($config->get('apollo.cluster', ''))
             ->setClientIp(current(swoole_get_local_ip()));
         $namespaces = $config->get('apollo.namespaces', []);
         $callbacks = [];

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -24,7 +24,7 @@ class ClientFactory
         $option = make(Option::class);
         $option->setServer($config->get('apollo.server', 'http://127.0.0.1:8080'))
             ->setAppid($config->get('apollo.appid', ''))
-            ->setCluster($config->get('apollo.cluster', ''))
+            ->setCluster($config->get('apollo.cluster', ''))  
             ->setClientIp(current(swoole_get_local_ip()));
         $namespaces = $config->get('apollo.namespaces', []);
         $callbacks = [];


### PR DESCRIPTION
目前apollo配置后台监控的实例列表的ip全是127.0.0.1, 没法正确监控到集群环境下每个服务器是否正确拉取到更新后的配置，增加了设置clientIp，用户区分不同服务器的请求