### PR TITLE
使用releasKey拉取apollo配置时，如果没有配置变化apollo会返回304并且没有返回body，此时不需要重置releaseK…

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -61,7 +61,7 @@ class Client implements ClientInterface
             $result = $this->blockingPull($namespaces);
         }
         foreach ($result as $namespace => $configs) {
-            if (isset($configs['releaseKey'], $configs['configurations'])) {
+            if (isset($configs['releaseKey'], $configs['configurations']) && !empty($configs['configurations'])) {
                 if (isset($callbacks[$namespace])) {
                     // Call the method level callbacks.
                     call($callbacks[$namespace], [$configs, $namespace]);


### PR DESCRIPTION
使用releasKey拉取apollo配置时，如果没有配置变化apollo会返回304并且没有返回body，此时不需要重置releaseKey的缓存，也不用去通知woker和process进程。这样可以节约资源，更重要的是目前在独立进程模式下，服务运行一段时间后会出现假死，debug日志后发现是卡死在$process->exportSocket()->send($string);，原因还不清楚，但是通过新增校验，可以很大程度避免apollo进程假死的问题