### PR TITLE
Fix composer requires

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
     },
     "require": {
         "php": ">=7.2",
+        "hyperf/command": "^2.1",
         "hyperf/contract": "~2.1.0",
+        "hyperf/framework": "^2.1",
         "hyperf/guzzle": "^2.1",
         "hyperf/utils": "~2.1.0",
         "psr/container": "^1.0"
@@ -27,7 +29,6 @@
     "require-dev": {
         "hyperf/config": "~2.1.0",
         "hyperf/event": "~2.1.0",
-        "hyperf/framework": "~2.1.0",
         "hyperf/process": "~2.1.0",
         "malukenho/docheader": "^0.1.6",
         "mockery/mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,10 @@
     },
     "require": {
         "php": ">=7.2",
-        "psr/container": "^1.0",
         "hyperf/contract": "~2.1.0",
-        "hyperf/utils": "~2.1.0"
+        "hyperf/guzzle": "^2.1",
+        "hyperf/utils": "~2.1.0",
+        "psr/container": "^1.0"
     },
     "require-dev": {
         "hyperf/config": "~2.1.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Tests">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
拆封了一下代码重新提了pr。require 添加理由已经在下方注明

`hyperf/command`  对应 `use Hyperf\Command\Event\BeforeHandle;`
`hyperf/framework` 对应 `use Hyperf\Framework\Event\BeforeWorkerStart;`
`hyperf/utils` 对应 `use Hyperf\Utils\Coroutine;`
`hyperf/guzzle` 对应 `use Hyperf\Guzzle\ClientFactory as GuzzleClientFactory;`
`psr/container` 对应 `use Psr\Container\ContainerInterface;`
